### PR TITLE
Set balance in ownedByAddress for each token returned in getOwned

### DIFF
--- a/src/modules/bundle.ts
+++ b/src/modules/bundle.ts
@@ -22,7 +22,7 @@ export interface BundleMetadata {
   creator: string;
   supply: BigNumber;
   metadata: NFTMetadata;
-  ownedByAddress: number;
+  ownedByAddress: BigNumber;
   underlyingType: UnderlyingType;
 }
 
@@ -118,7 +118,7 @@ export class BundleModule
       creator: state.creator,
       supply,
       metadata,
-      ownedByAddress,
+      ownedByAddress: BigNumber.from(ownedByAddress),
       underlyingType: state.underlyingType,
     };
   }
@@ -459,7 +459,10 @@ export class BundleModule
       })
       .filter((b) => b.balance.gt(0));
     return await Promise.all(
-      ownedBalances.map(async (b) => await this.get(b.tokenId.toString())),
+      ownedBalances.map(async ({ tokenId, balance }) => {
+        const token = await this.get(tokenId.toString());
+        return { ...token, ownedByAddress: balance };
+      }),
     );
   }
 

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -59,6 +59,24 @@ describe("Bundle Module (aka Collection Module)", async () => {
       .length(0, "Bob should not have any nfts");
   });
 
+  it("should return non-zero balance of owned collection tokens", async () => {
+    const token = await nftModule.mint({
+      name: "test",
+    });
+
+    try {
+      await collectionModule.createWithERC721(nftModule.address, token.id, {
+        name: "TEST NFT",
+      });
+    } catch (err) {
+      assert.fail(err);
+    }
+
+    const nfts = await bundleModule.getOwned(adminWallet.address);
+    expect(nfts).to.be.an("array").length(1);
+    assert.isTrue(nfts[0].ownedByAddress.eq(1));
+  });
+
   it("should create a new collection using token", async () => {
     await currencyModule.mint(100);
 


### PR DESCRIPTION
This PR updates the bundle/collection module `getOwned` function so that it returns the number of each token owned by the user in the `ownedByAddress` field. Currently it returns 0 in this field for all tokens. This allows consumers to get the metadata and balance of every owned token in a bundle for a given address in a single call to `getOwned`. 

This was discussed on Discord and agreed as a bug (partner channel link): https://discord.com/channels/834227967404146718/915738548848713818/929025948999884901

Note that because `ownedByAddress` holds a number (not BigNumber), I've added an additional check and we return `Number.MAX_SAFE_INTEGER` if the number owned is greater than this number. 