### PR TITLE
Add getOwned function to pack module

### DIFF
--- a/src/modules/pack.ts
+++ b/src/modules/pack.ts
@@ -43,6 +43,14 @@ export interface PackNFTMetadata {
   supply: BigNumber;
   metadata: NFTMetadata;
 }
+
+/**
+ * @public
+ */
+export interface PackMetadataWithBalance extends PackMetadata {
+  ownedByAddress: BigNumber;
+}
+
 export enum UnderlyingType {
   None = 0,
   ERC20 = 1,
@@ -88,8 +96,7 @@ export interface IPackBatchArgs {
  */
 export class PackModule
   extends ModuleWithRoles<PackContract>
-  implements ITransferable
-{
+  implements ITransferable {
   public static moduleType: ModuleType = ModuleType.PACK;
 
   public static roles = [
@@ -562,5 +569,36 @@ export class PackModule
   ): Promise<TransactionReceipt> {
     await this.onlyRoles(["admin"], await this.getSignerAddress());
     return await this.sendTransaction("setRestrictedTransfer", [restricted]);
+  }
+
+  /**
+   * `getOwned` is a convenience method for getting all owned tokens
+   * for a particular wallet.
+   *
+   * @param _address - The address to check for token ownership
+   * @returns An array of PackMetadataWithBalance objects that are owned by the address
+   */
+  public async getOwned(_address?: string): Promise<PackMetadataWithBalance[]> {
+    const address = _address ? _address : await this.getSignerAddress();
+    const maxId = await this.readOnlyContract.nextTokenId();
+    const balances = await this.readOnlyContract.balanceOfBatch(
+      Array(maxId.toNumber()).fill(address),
+      Array.from(Array(maxId.toNumber()).keys()),
+    );
+
+    const ownedBalances = balances
+      .map((b, i) => {
+        return {
+          tokenId: i,
+          balance: b,
+        };
+      })
+      .filter((b) => b.balance.gt(0));
+    return await Promise.all(
+      ownedBalances.map(async ({ tokenId, balance }) => {
+        const token = await this.get(tokenId.toString());
+        return { ...token, ownedByAddress: balance };
+      }),
+    );
   }
 }

--- a/test/pack.test.ts
+++ b/test/pack.test.ts
@@ -160,4 +160,27 @@ describe("Pack Module", async () => {
       const pack = await createPacks();
     });
   });
+
+  describe("Get owned packs", async () => {
+    beforeEach(async () => {
+      await createBundles();
+    });
+
+    it("get owned returns pack metadata and balances", async () => {
+      const pack = await createPacks();
+
+      let adminOwned = await packModule.getOwned();
+      assert.equal(adminOwned.length, 2);
+      assert.equal(adminOwned[0].ownedByAddress.toString(), "150");
+      assert.equal(adminOwned[1].ownedByAddress.toString(), "75");
+
+      await packModule.transfer(samWallet.address, "0", BigNumber.from(50));
+      const samOwned = await packModule.getOwned(samWallet.address);
+      assert.equal(samOwned.length, 1);
+      assert.equal(samOwned[0].ownedByAddress.toString(), "50");
+
+      adminOwned = await packModule.getOwned();
+      assert.equal(adminOwned[0].ownedByAddress.toString(), "100");
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a `getOwned` function to the pack module, with the same behaviour as the one in the collection module. It can be used to display the packs owned by an address and their respective balances.

As with the equivalent function in the collection module it's a convenience function that saves SDK consumers tracking multiple requests to get NFT metadata and balances individually. 

Example output:

```
[
  {
    id: '0',
    metadata: {
      name: 'Pack',
      id: '0',
      uri: 'ipfs://QmYg3zbsu6Sf8cCmEuJZBerUuxKH1ihgzUER1zwHYAMd2D/0'
    },
    creator: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
    currentSupply: BigNumber { value: "150" },
    openStart: 2022-01-17T10:21:53.000Z,
    ownedByAddress: BigNumber { value: "150" }
  },
  {
    id: '1',
    metadata: {
      name: 'Pack',
      id: '1',
      uri: 'ipfs://QmYg3zbsu6Sf8cCmEuJZBerUuxKH1ihgzUER1zwHYAMd2D/0'
    },
    creator: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
    currentSupply: BigNumber { value: "75" },
    openStart: 2022-01-17T10:21:56.000Z,
    ownedByAddress: BigNumber { value: "75" }
  }
]
```